### PR TITLE
[STEP 4] Connect LangChain4j to Claude

### DIFF
--- a/src/main/java/com/example/agent/agent/BacklogAgent.java
+++ b/src/main/java/com/example/agent/agent/BacklogAgent.java
@@ -1,0 +1,25 @@
+package com.example.agent.agent;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+public interface BacklogAgent {
+
+    @SystemMessage("""
+            You are a GitHub backlog agent.
+            
+            When the user asks to create a task/issue, you MUST call the available GitHub issue creation tool.
+            Do NOT claim tools are unavailable unless you attempted a tool call and it failed.
+            
+            The issue body must include:
+            - Context
+            - Goal
+            - Acceptance Criteria
+            
+            Never expose secrets.
+            The repository owner/repo are preconfigured. Do not ask for them.
+            """)
+    @UserMessage("User request: {{prompt}}")
+    String handle(@V("prompt") String prompt);
+}

--- a/src/main/java/com/example/agent/config/LangChainConfig.java
+++ b/src/main/java/com/example/agent/config/LangChainConfig.java
@@ -1,0 +1,42 @@
+package com.example.agent.config;
+
+import com.example.agent.agent.BacklogAgent;
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.service.AiServices;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+public class LangChainConfig {
+
+    @Bean
+    public AnthropicChatModel anthropicChatModel(
+            @Value("${anthropic.api-key}") String apiKey,
+            @Value("${anthropic.model}") String model,
+            @Value("${anthropic.max-tokens:800}") Integer maxTokens,
+            @Value("${anthropic.timeout-seconds:60}") Integer timeoutSeconds
+    ) {
+        return AnthropicChatModel.builder()
+                .apiKey(apiKey)
+                .modelName(model)
+                .maxTokens(maxTokens)
+                .timeout(Duration.ofSeconds(timeoutSeconds))
+                .build();
+    }
+
+    @Bean
+    public BacklogAgent backlogAgent(AnthropicChatModel model,
+                                     ObjectProvider<List<Object>> toolBeansProvider) {
+        List<Object> toolBeans = toolBeansProvider.getIfAvailable(List::of);
+
+        return AiServices.builder(BacklogAgent.class)
+                .chatModel(model)
+                .tools(toolBeans)
+                .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: agent-test
+
+github:
+  owner: test-owner
+  repo: test-repo
+
+anthropic:
+  api-key: test-key
+  model: claude-opus-4-20250514
+  max-tokens: 800
+  timeout-seconds: 60
+
+mcp:
+  base-url: http://localhost:3333
+  path: /mcp


### PR DESCRIPTION
## What
Connect LangChain4j to Claude (Anthropic) to enable AI reasoning.

## Changes
- BacklogAgent interface created in agent/
- LangChainConfig created in config/
- AnthropicChatModel bean configured
- BacklogAgent bean built with AiServices
- Test application.yml added with stub values

Closes #12